### PR TITLE
added public Static preferences

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.3.1.1514")]
+[assembly: AssemblyVersion("1.3.1.1963")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.3.1.1514")]
+[assembly: AssemblyFileVersion("1.3.1.1963")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.3.1.1963")]
+[assembly: AssemblyVersion("1.3.1.1977")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.3.1.1963")]
+[assembly: AssemblyFileVersion("1.3.1.1977")]

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -175,7 +175,7 @@ namespace Dynamo.Models
         /// Setting this flag enables creation of an XML in following format that records
         /// node mapping information - which old node has been converted to which to new node(s)
         /// </summary>
-        public static string TestStaticProp { get { return "this is a static property"; }  }
+        public static PreferenceSettings PublicSettings { get; set; }
 
         #endregion
 
@@ -284,7 +284,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     Preference settings for this instance of Dynamo.
         /// </summary>
-        public readonly PreferenceSettings PreferenceSettings;
+        public static readonly PreferenceSettings PreferenceSettings;
 
         /// <summary>
         ///     Node Factory, used for creating and intantiating loaded Dynamo nodes.
@@ -545,6 +545,7 @@ namespace Dynamo.Models
             if (settings != null)
             {
                 PreferenceSettings = settings;
+                PublicSettings = settings;
                 PreferenceSettings.PropertyChanged += PreferenceSettings_PropertyChanged;
             }
 
@@ -570,10 +571,12 @@ namespace Dynamo.Models
                 {
                     var isFirstRun = PreferenceSettings.IsFirstRun;
                     PreferenceSettings = migrator.PreferenceSettings;
+                    PublicSettings = migrator.PreferenceSettings;
 
                     // Preserve the preference settings for IsFirstRun as this needs to be set
                     // only by UsageReportingManager
                     PreferenceSettings.IsFirstRun = isFirstRun;
+                    PublicSettings.IsFirstRun = isFirstRun;
                 }
             }
             InitializePreferences(PreferenceSettings);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -171,6 +171,12 @@ namespace Dynamo.Models
         /// </summary>
         public static bool EnableMigrationLogging { get; set; }
 
+        /// <summary>
+        /// Setting this flag enables creation of an XML in following format that records
+        /// node mapping information - which old node has been converted to which to new node(s)
+        /// </summary>
+        public static string TestStaticProp { get { return "this is a static property"; }  }
+
         #endregion
 
         #region public properties

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -284,7 +284,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     Preference settings for this instance of Dynamo.
         /// </summary>
-        public static readonly PreferenceSettings PreferenceSettings;
+        public readonly PreferenceSettings PreferenceSettings;
 
         /// <summary>
         ///     Node Factory, used for creating and intantiating loaded Dynamo nodes.

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -11,9 +11,6 @@ using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.IO;
-using Dynamo.Configuration;
-using System.Windows.Forms;
-using System.Web.Script.Serialization;
 
 namespace PythonNodeModels
 {

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -12,6 +12,7 @@ using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 using System.IO;
 using Dynamo.Configuration;
+using System.Windows.Forms;
 
 namespace PythonNodeModels
 {
@@ -70,6 +71,8 @@ namespace PythonNodeModels
     {
         public PythonNode()
         {
+            var settings = Dynamo.Models.DynamoModel.TestStaticProp;
+            MessageBox.Show("Dynamo settings say that :" + Environment.NewLine + settings);
             var pythonTemplatePath = new PreferenceSettings().PythonTemplateFilePath;
             if (!String.IsNullOrEmpty(pythonTemplatePath) && File.Exists(pythonTemplatePath))
                 script = File.ReadAllText(pythonTemplatePath);

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -13,6 +13,7 @@ using ProtoCore.AST.AssociativeAST;
 using System.IO;
 using Dynamo.Configuration;
 using System.Windows.Forms;
+using System.Web.Script.Serialization;
 
 namespace PythonNodeModels
 {
@@ -71,8 +72,9 @@ namespace PythonNodeModels
     {
         public PythonNode()
         {
-            var settings = Dynamo.Models.DynamoModel.TestStaticProp;
-            MessageBox.Show("Dynamo settings say that :" + Environment.NewLine + settings);
+            var settings = Dynamo.Models.DynamoModel.PublicSettings;
+            var json = new JavaScriptSerializer().Serialize(settings);
+            MessageBox.Show("Dynamo settings say that :" + Environment.NewLine + json);
             var pythonTemplatePath = new PreferenceSettings().PythonTemplateFilePath;
             if (!String.IsNullOrEmpty(pythonTemplatePath) && File.Exists(pythonTemplatePath))
                 script = File.ReadAllText(pythonTemplatePath);

--- a/src/Libraries/PythonNodeModels/PythonNode.cs
+++ b/src/Libraries/PythonNodeModels/PythonNode.cs
@@ -72,22 +72,19 @@ namespace PythonNodeModels
     {
         public PythonNode()
         {
-            var settings = Dynamo.Models.DynamoModel.PublicSettings;
-            var json = new JavaScriptSerializer().Serialize(settings);
-            MessageBox.Show("Dynamo settings say that :" + Environment.NewLine + json);
-            var pythonTemplatePath = new PreferenceSettings().PythonTemplateFilePath;
+            var pythonTemplatePath = Dynamo.Models.DynamoModel.PublicPreferenceSettings.PythonTemplateFilePath;
             if (!String.IsNullOrEmpty(pythonTemplatePath) && File.Exists(pythonTemplatePath))
                 script = File.ReadAllText(pythonTemplatePath);
             else
-                script = Properties.Resources.PythonScriptEditorImports + Environment.NewLine + 
+                script = "#" + Properties.Resources.PythonScriptEditorImports + Environment.NewLine + 
                     "import clr" + Environment.NewLine + 
                     "clr.AddReference('ProtoGeometry')" + Environment.NewLine +
                     "from Autodesk.DesignScript.Geometry import *" + Environment.NewLine +
                     "#" + Properties.Resources.PythonScriptEditorInputComment + Environment.NewLine +
-                    "dataEnteringNode = IN" + Environment.NewLine + Environment.NewLine + Environment.NewLine +
-                    Properties.Resources.PythonScriptEditorCodeComment + Environment.NewLine + Environment.NewLine +
+                    "dataEnteringNode = IN" + Environment.NewLine + Environment.NewLine + 
+                    "#" + Properties.Resources.PythonScriptEditorCodeComment + Environment.NewLine + Environment.NewLine +
                     "#" + Properties.Resources.PythonScriptEditorOutputComment + Environment.NewLine +
-                    "OUT = 0";
+                    "OUT = yourOutputVariableHere";
 
             AddInput();
 

--- a/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
+++ b/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
@@ -45,6 +45,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
+++ b/src/Libraries/PythonNodeModels/PythonNodeModels.csproj
@@ -45,8 +45,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
### Purpose

Added a `public`  `static` property called `PublicPreferenceSettings` to `DynamoModel` class, so that nodes and other components that are not fully aware of the context they're executed in can still access these properties.

The property should be thread-safe as it's read-only :
- read : `public` access
- write : `internal` access

Also added lines to update the static property whenever the instance-based `PreferenceSettings` gets updated within the `DynamoModel` class.

Tested by

- [x] building
- [x] running `DynamoSandbox`
- [x] changing Dynamo settings (such as `show connectors` or adding a new custom package path)
- [x] nodes reading the static property see the updates

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@radumg

### FYIs
