### PR TITLE
Address browser testing issues on test machines

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Wpf.Utilities
 
             // provide fallback values for text content in case Resources or Assembly calls fail
             var issueTitle = Properties.Resources.CrashPromptGithubNewIssueTitle ?? "Crash report from Dynamo {0}";
-            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.2+";
+            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.1.0+";
             var content = GithhubCrashReportBody(crashContent);
 
             // append the title and body to the URL as query parameters
@@ -35,8 +35,8 @@ namespace Dynamo.Wpf.Utilities
         {
             var stackTrace = details?.ToString() ?? string.Empty;
 
-            // This functionality was not available prior to version 2.2, so it should be the fallback value
-            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.2+";
+            // This functionality was not available prior to version 2.1.0, so it should be the fallback value
+            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.1.0+";
 
             return BuildMarkdownContent(dynamoVersion, stackTrace);
         }

--- a/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
@@ -6,7 +6,6 @@ namespace Dynamo.Wpf.Utilities
 {
     static class CrashUtilities
     {
-
         internal static string GithubNewIssueUrlFromCrashContent(object crashContent)
         {
             var baseUri = new UriBuilder(Configurations.GitHubBugReportingLink);
@@ -34,28 +33,38 @@ namespace Dynamo.Wpf.Utilities
         /// <returns>A formatted, but not escaped, string to use as issue body.</returns>
         private static string GithhubCrashReportBody(object details)
         {
-            var content = details?.ToString() ?? string.Empty;
+            var stackTrace = details?.ToString() ?? string.Empty;
 
             // This functionality was not available prior to version 2.2, so it should be the fallback value
             var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.2+";
 
-            return
-                "# Issue Description" + Environment.NewLine +
-                "Please fill in the following information to help us reproduce the issue:" + Environment.NewLine +
-                "### What did you do?" + Environment.NewLine +
-                "(Fill in here)" + Environment.NewLine +
-                "### What did you expect to see?" + Environment.NewLine +
-                "(Fill in here)" + Environment.NewLine +
-                "### What did you see instead?" + Environment.NewLine +
-                "(Fill in here)" + Environment.NewLine +
-                "### What packages or external references (if any) were used?" + Environment.NewLine +
-                "(Fill in here)" + Environment.NewLine + Environment.NewLine +
-                "---" + Environment.NewLine +
-                "OS: " + "`" + Environment.OSVersion + "`" + Environment.NewLine +
-                "CLR: " + "`" + Environment.Version + "`" + Environment.NewLine +
-                "Dynamo: " + "`" + dynamoVersion + "`" + Environment.NewLine +
-                "Details: " + Environment.NewLine + "```" + Environment.NewLine + content + Environment.NewLine + "```";
+            return BuildMarkdownContent(dynamoVersion, stackTrace);
         }
 
+        /// <summary>
+        /// Builds a Markdown string that will be posted to our new GitHub issue
+        /// </summary>
+        /// <param name="dynamoVersion">Dynamo version that should be recorded in the issue report</param>
+        /// <param name="stackTrace">The crash stack trace to be included in the issue report</param>
+        /// <returns></returns>
+        internal static string BuildMarkdownContent(string dynamoVersion, string stackTrace)
+        {
+            return
+            "# Issue Description" + Environment.NewLine +
+            "Please fill in the following information to help us reproduce the issue:" + Environment.NewLine +
+            "### What did you do?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What did you expect to see?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What did you see instead?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What packages or external references (if any) were used?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine + Environment.NewLine +
+            "---" + Environment.NewLine +
+            "OS: " + "`" + Environment.OSVersion + "`" + Environment.NewLine +
+            "CLR: " + "`" + Environment.Version + "`" + Environment.NewLine +
+            "Dynamo: " + "`" + dynamoVersion + "`" + Environment.NewLine +
+            "Details: " + Environment.NewLine + "```" + Environment.NewLine + stackTrace + Environment.NewLine + "```";
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -1,131 +1,104 @@
-﻿using Dynamo.ViewModels;
-using NUnit.Framework;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Dynamo.ViewModels;
+using NUnit.Framework;
 
 namespace Dynamo.Tests
 {
     [TestFixture]
     public class CrashReportingTests
     {
-        /// <summary>
-        /// Browser tab open on the GitHub new issue page should contain these words in the title
-        /// </summary>
-        List<string> TargetWords = new List<string> { "NEW ISSUE", "DYNAMODS" };
-        /// <summary>
-        /// If user is not logged in to GitHub, browser tab trying to open the GitHub new issue page should contain these words in the title
-        /// </summary>
-        List<string> TargetWordsLoggedOutFallback = new List<string> { "SIGN IN", "GITHUB" };
-
         // This is the stack trace produced by the known crash produced when 
         // opening the Core.Math sample, selecting all nodes and doing NodeToCode.
         private string StackTrace = @"
-Object reference not set to an instance of an object.
-
-   at Dynamo.Graph.Nodes.CodeBlockNodeModel.GetTypeHintForOutput(Int32 index)
-   at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.GetInputOutputMap(IEnumerable`1 nodes, Dictionary`2& inputMap, Dictionary`2& outputMap, Dictionary`2& renamingMap, Dictionary`2& typeHintMap)
-   at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.NodeToCode(Core core, IEnumerable`1 workspaceNodes, IEnumerable`1 nodes, INamingProvider namingProvider)
-   at Dynamo.Graph.Workspaces.NodesToCodeExtensions.ConvertNodesToCodeInternal(WorkspaceModel workspace, EngineController engineController, INamingProvider namingProvider)
-   at Dynamo.Models.DynamoModel.ConvertNodesToCodeImpl(ConvertNodesToCodeCommand command)
-   at Dynamo.Models.DynamoModel.ExecuteCommand(RecordableCommand command)
-   at MS.Internal.Commands.CommandHelpers.CriticalExecuteCommandSource(ICommandSource commandSource, Boolean userInitiated)
-   at System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
-   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
-   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
-   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
-   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
-   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
-   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
-   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
-   at System.Windows.Threading.DispatcherOperation.Invoke()
-   at System.Windows.Threading.Dispatcher.ProcessQueue()
-   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
-   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
-   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
-   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
-   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
-   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
-   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
-   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
-   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
-   at System.Windows.Application.RunDispatcher(Object ignore)
-   at System.Windows.Application.RunInternal(Window window)
-   at DynamoSandbox.DynamoCoreSetup.RunApplication(Application app)";
+            Object reference not set to an instance of an object.
+            at Dynamo.Graph.Nodes.CodeBlockNodeModel.GetTypeHintForOutput(Int32 index)
+            at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.GetInputOutputMap(IEnumerable`1 nodes, Dictionary`2& inputMap, Dictionary`2& outputMap, Dictionary`2& renamingMap, Dictionary`2& typeHintMap)
+            at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.NodeToCode(Core core, IEnumerable`1 workspaceNodes, IEnumerable`1 nodes, INamingProvider namingProvider)
+            at Dynamo.Graph.Workspaces.NodesToCodeExtensions.ConvertNodesToCodeInternal(WorkspaceModel workspace, EngineController engineController, INamingProvider namingProvider)
+            at Dynamo.Models.DynamoModel.ConvertNodesToCodeImpl(ConvertNodesToCodeCommand command)
+            at Dynamo.Models.DynamoModel.ExecuteCommand(RecordableCommand command)
+            at MS.Internal.Commands.CommandHelpers.CriticalExecuteCommandSource(ICommandSource commandSource, Boolean userInitiated)
+            at System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
+            at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
+            at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
+            at System.Windows.Threading.DispatcherOperation.InvokeImpl()
+            at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
+            at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
+            at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
+            at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
+            at System.Windows.Threading.DispatcherOperation.Invoke()
+            at System.Windows.Threading.Dispatcher.ProcessQueue()
+            at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
+            at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
+            at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
+            at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
+            at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
+            at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
+            at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
+            at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
+            at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
+            at System.Windows.Application.RunDispatcher(Object ignore)
+            at System.Windows.Application.RunInternal(Window window)
+            at DynamoSandbox.DynamoCoreSetup.RunApplication(Application app)";
 
         [Test]
         public void CanReportBugWithNoContent()
         {
-            // report a bug with no details
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(null, null);
+            Assert.IsNotNullOrEmpty(crashReport);
+
+            // Mock url for request
+            string url = Wpf.Utilities.CrashUtilities.GithubNewIssueUrlFromCrashContent(crashReport);
+            Assert.IsNotNullOrEmpty(url);
+
+            // Report a bug with no details
             Assert.DoesNotThrow(() => DynamoViewModel.ReportABug());
-
-            // give the system time to launch a browser & open the page
-            Thread.Sleep(4000);
-
-            // check browser is open on correct page
-            Assert.True(BrowserIsOpenOnPageWithTitleMatching(TargetWords));
         }
 
         [Test]
         public void CanReportBugWithContent()
         {
-            // report a bug with details
-            var details = "Exception thrown somewhere";
-            Assert.IsNotNull(details);
-            Assert.DoesNotThrow(() => DynamoViewModel.ReportABug(details));
+            // Mock Dynamo version
+            var dynamoVersion = "2.1.0";
 
-            // give the system time to launch a browser & open the page
-            Thread.Sleep(4000);
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(dynamoVersion, StackTrace);
+            Assert.IsNotNullOrEmpty(crashReport);
 
-            // check browser is open on correct page
-            Assert.True(BrowserIsOpenOnPageWithTitleMatching(TargetWords));
+            // Report a bug with a stack tace
+            Assert.DoesNotThrow(() => DynamoViewModel.ReportABug(crashReport));
         }
 
         [Test]
-        public void CanReportBugWithLongContent()
+        public void StackTraceIncludedInReport()
         {
-            // report a bug with very long content
-            Assert.IsNotNull(StackTrace);
-            Assert.DoesNotThrow(() => DynamoViewModel.ReportABug(StackTrace));
+            // Mock Dynamo version
+            var dynamoVersion = "2.1.0";
 
-            // give the system time to launch a browser & open the page
-            Thread.Sleep(4000);
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(dynamoVersion, StackTrace);
+            Assert.IsNotNullOrEmpty(crashReport);
 
-            // check browser is open on correct page
-            Assert.True(BrowserIsOpenOnPageWithTitleMatching(TargetWords));
-        }
+            // Mock url for request
+            string url = Wpf.Utilities.CrashUtilities.GithubNewIssueUrlFromCrashContent(crashReport);
+            Assert.IsNotNullOrEmpty(url);
 
+            // Get body content from request
+            var query = "body=";
+            var startIndex = url.IndexOf(query) + query.Length;
+            var body = url.Substring(startIndex);
+            var decoded = Uri.UnescapeDataString(body);
 
-        /// <summary>
-        /// Checks there is a process open whose main window title matches the supplied words.
-        /// </summary>
-        /// <param name="pageTitleWords">The words to match.</param>
-        /// <returns></returns>
-        private bool BrowserIsOpenOnPageWithTitleMatching(List<string> pageTitleWords)
-        {
-            // get list of all processes on the system
-            var allProcesses = Process.GetProcesses();
+            // Verify request contains the dynamoVersion
+            Assert.True(decoded.Contains(dynamoVersion));
 
-            // find processes whose main window title matches our keywords
-            var matchingProcesses = allProcesses
-                                        .Select(x => x.MainWindowTitle)
-                                        .Where(title => ContainsAllTargetWords(title))
-                                        .ToList();
-
-            // check that at least one process matches our search
-            return matchingProcesses.Any();
-        }
-
-        /// <summary>
-        /// Checks if a supplied string contains all target substrings
-        /// </summary>
-        /// <param name="source">The string to check</param>
-        /// <returns></returns>
-        private bool ContainsAllTargetWords(string source)
-        {
-            return TargetWords.TrueForAll(x => source.ToUpper().Contains(x)) ||
-                   TargetWordsLoggedOutFallback.TrueForAll(x => source.ToUpper().Contains(x));
+            // Verify request contains the stack trace
+            Assert.True(decoded.Contains(StackTrace));
         }
     }
 }

--- a/test/DynamoCoreWpfTests/Properties/AssemblyInfo.cs
+++ b/test/DynamoCoreWpfTests/Properties/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using NUnit.Framework;
 [assembly: Guid("0e3a9cb1-69eb-4fc1-ab44-5fa36cfaa906")]
 [assembly: RequiresThread(ApartmentState.STA)]
 [assembly: InternalsVisibleTo("WpfVisualizationTests")]
+[assembly: InternalsVisibleTo("CrashReportingTests")]


### PR DESCRIPTION
### Purpose

This PR addresses browser testing issues on test machines.  Verifying content running in a browser process launched via Dynamo is difficult to maintain on the test machines as the browser settings can often be reset or modified.  The original tests worked great locally but pop-up browser messages preventing the tests from successfully executing on the test machines.  These changes simply the tests while not relying on the browser content.

### Reviewers

@radumg 


